### PR TITLE
Added spine with settings for spine color and spine children.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ return (
 | radius             | `number` | Radius of right corners, in pixels                     | `2`       |
 | thickness          | `number` | Book thickness, in pixels                              | `50`      |
 | bgColor            | `string` | Color of the inside of back cover                      | `#01060f` |
+| spineColor         | `string` | Color of the spine of the book, as css color value or image url  | `#01060f` |
+| spineChildren      | `React.ReactNode` | Children or content to put in the spine                      | `null` |
 | width              | `number` | Width of the book, in pixels                           | `200`     |
 | height             | `number` | Height of the book, in pixels                          | `300`     |
 | pagesOffset        | `number` | Offset between the pages and the cover size, in pixels | `3`       |
@@ -80,6 +82,8 @@ return (
     radius={5}
     thickness={30}
     bgColor="#1e3a8a"
+    spineColor="#1e3a8a"
+    spineChildren={<div className="book-spine-title">1</div>}
     width={300}
     height={200}
     pagesOffset={5}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,14 @@ export interface Settings {
    */
   bgColor: string
   /**
+   * Color of the spine of the book. Accepts a css color value or url image.
+   */
+  spineColor: string
+  /**
+   * Children or content to put in the spine.
+   */
+  spineChildren: React.ReactNode
+  /**
    * Color of box shadow.
    */
   shadowColor: string
@@ -67,6 +75,8 @@ export const BookCover = ({
   width = 200,
   height = 300,
   pagesOffset = 3,
+  spineColor = 'black',
+  spineChildren = null,
 }: Props) => {
   const uniqueId = useMemo(
     () =>
@@ -87,13 +97,18 @@ export const BookCover = ({
     width,
     height,
     pagesOffset,
+    spineColor,
+    spineChildren,
   })
 
   return (
     <>
       <style>{css}</style>
       <div className={`book-container-${uniqueId}`}>
-        <div className="book">{children}</div>
+        <div className="book">
+          {children}
+          <div className="book-spine">{spineChildren}</div>
+        </div>
       </div>
     </>
   )
@@ -190,6 +205,24 @@ export const getCssForSettings = (uniqueId: string, settings: Settings) => {
       background-color: ${settings.bgColor};
       border-radius: 0 ${settings.radius}px ${settings.radius}px 0;
       box-shadow: -10px 0 50px 10px ${settings.shadowColor};
+    }
+
+    .book-spine {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: ${settings.thickness + 2}px;
+      bottom: 0;
+      transform: translateX(0) translateZ(${-(settings.thickness + 2) /
+        2}px) rotateY(-90deg);
+      transform-style: preserve-3d;
+      transform-origin: left;
+      background: ${settings.spineColor};
+      /* Default settings for spine content */
+      /* Center spine content */
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
   `
 }


### PR DESCRIPTION
I noticed that when the book is rotated to show the spine, there was just a gap. I added a spine to the component that can be styled with a css background value (and thus a color or image). The new spine also accepts children through `spineChildren`, allowing the implementer to design a custom spine or add a title to the spine.

I also updated the Readme to reflect these changes.